### PR TITLE
Add multi-targeting to unit test project with net481 support

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -13,7 +13,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Setup .NET
+    - name: Setup .NET 6
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 6.0.x
+    - name: Setup .NET 8
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 8.0.x

--- a/test/F23.StringSimilarity.Tests/DamerauTest.cs
+++ b/test/F23.StringSimilarity.Tests/DamerauTest.cs
@@ -24,7 +24,6 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Text;
 using F23.StringSimilarity.Tests.TestUtil;
 using Xunit;
 
@@ -48,11 +47,11 @@ namespace F23.StringSimilarity.Tests
             
             // test char span version
             Assert.Equal(expected, actual: instance.Distance(s1.AsSpan(), s2.AsSpan()));
-            
+
             // test byte span version
             Assert.Equal(expected, actual: instance.Distance<byte>(
-                Encoding.Latin1.GetBytes(s1).AsSpan(), 
-                Encoding.Latin1.GetBytes(s2).AsSpan()));
+                EncodingUtil.Latin1.GetBytes(s1).AsSpan(), 
+                EncodingUtil.Latin1.GetBytes(s2).AsSpan()));
         }
         
         [Fact]

--- a/test/F23.StringSimilarity.Tests/F23.StringSimilarity.Tests.csproj
+++ b/test/F23.StringSimilarity.Tests/F23.StringSimilarity.Tests.csproj
@@ -1,7 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net481</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/F23.StringSimilarity.Tests/JaroWinklerTest.cs
+++ b/test/F23.StringSimilarity.Tests/JaroWinklerTest.cs
@@ -59,8 +59,8 @@ namespace F23.StringSimilarity.Tests
             Assert.Equal(
                 expected,
                 actual: instance.Similarity<byte>(
-                    System.Text.Encoding.Latin1.GetBytes(s1).AsSpan(),
-                    System.Text.Encoding.Latin1.GetBytes(s2).AsSpan()),
+                    EncodingUtil.Latin1.GetBytes(s1).AsSpan(),
+                    EncodingUtil.Latin1.GetBytes(s2).AsSpan()),
                 precision: 6 // 0.000001
             );
         }

--- a/test/F23.StringSimilarity.Tests/LevenshteinTest.cs
+++ b/test/F23.StringSimilarity.Tests/LevenshteinTest.cs
@@ -50,8 +50,8 @@ namespace F23.StringSimilarity.Tests
             
             // test byte span version
             Assert.Equal(expected, actual: instance.Distance<byte>(
-                System.Text.Encoding.Latin1.GetBytes(s1).AsSpan(), 
-                System.Text.Encoding.Latin1.GetBytes(s2).AsSpan()));
+                EncodingUtil.Latin1.GetBytes(s1).AsSpan(), 
+                EncodingUtil.Latin1.GetBytes(s2).AsSpan()));
         }
 
         [InlineData("My string", "M string2", 4, 2.0)]
@@ -70,8 +70,8 @@ namespace F23.StringSimilarity.Tests
             
             // test byte span version
             Assert.Equal(expected, actual: instance.Distance<byte>(
-                System.Text.Encoding.Latin1.GetBytes(s1).AsSpan(), 
-                System.Text.Encoding.Latin1.GetBytes(s2).AsSpan(), 
+                EncodingUtil.Latin1.GetBytes(s1).AsSpan(), 
+                EncodingUtil.Latin1.GetBytes(s2).AsSpan(), 
                 limit));
         }
         

--- a/test/F23.StringSimilarity.Tests/LongestCommonSubsequenceTest.cs
+++ b/test/F23.StringSimilarity.Tests/LongestCommonSubsequenceTest.cs
@@ -51,8 +51,8 @@ namespace F23.StringSimilarity.Tests
             
             // test byte span version
             Assert.Equal(expected, actual: instance.Distance<byte>(
-                System.Text.Encoding.Latin1.GetBytes(s1).AsSpan(), 
-                System.Text.Encoding.Latin1.GetBytes(s2).AsSpan()));
+                EncodingUtil.Latin1.GetBytes(s1).AsSpan(), 
+                EncodingUtil.Latin1.GetBytes(s2).AsSpan()));
         }
         
         [Fact]

--- a/test/F23.StringSimilarity.Tests/OptimalStringAlignmentTest.cs
+++ b/test/F23.StringSimilarity.Tests/OptimalStringAlignmentTest.cs
@@ -69,8 +69,8 @@ namespace F23.StringSimilarity.Tests
             Assert.Equal(
                 expected: expected,
                 actual: instance.Distance<byte>(
-                    System.Text.Encoding.Latin1.GetBytes(s1).AsSpan(),
-                    System.Text.Encoding.Latin1.GetBytes(s2).AsSpan()),
+                    EncodingUtil.Latin1.GetBytes(s1).AsSpan(),
+                    EncodingUtil.Latin1.GetBytes(s2).AsSpan()),
                 precision: 0 // 0.0
             );
         }

--- a/test/F23.StringSimilarity.Tests/TestUtil/EncodingUtil.cs
+++ b/test/F23.StringSimilarity.Tests/TestUtil/EncodingUtil.cs
@@ -1,0 +1,13 @@
+﻿using System.Text;
+
+namespace F23.StringSimilarity.Tests.TestUtil;
+
+internal class EncodingUtil
+{
+    public static Encoding Latin1 =>
+#if NET5_0_OR_GREATER
+        Encoding.Latin1;
+#else
+        Encoding.GetEncoding("ISO-8859-1");
+#endif
+}


### PR DESCRIPTION
This adds multi-targeting to the unit test project, with .NET 6 and .NET 8 by default, adding .NET Framework 4.8.1 when running on Windows only.

In order to support .NET Framework, which does not have `Encoding.Latin1`, a new `EncodingUtil` class was added.