### PR TITLE
Add NuGet package packing and artifact upload to CI workflow

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -29,3 +29,13 @@ jobs:
       run: dotnet build --no-restore
     - name: Test
       run: dotnet test --no-build --verbosity normal
+    - name: Pack NuGet packages
+      if: github.event_name != 'pull_request' && matrix.os == 'windows-latest'
+      run: dotnet pack --no-build --output nupkgs
+    - name: Upload NuGet packages
+      if: github.event_name != 'pull_request' && matrix.os == 'windows-latest'
+      uses: actions/upload-artifact@v4
+      with:
+        name: nuget-packages
+        path: nupkgs/
+        retention-days: 30


### PR DESCRIPTION
## Summary
- Automatically pack NuGet packages on successful builds
- Upload packages as artifacts for easy download from build details page
- Only runs on non-PR builds and Windows builds to avoid duplication

## Test plan
- [ ] Verify NuGet packages are packed and uploaded on successful main/develop branch builds
- [x] Verify the step is skipped on pull request builds
- [x] Verify the step is skipped on Ubuntu and macOS builds
- [ ] Download artifacts from a successful build and verify package contents

🤖 Generated with [Claude Code](https://claude.com/claude-code)