### PR TITLE
Enable CI on release/* branches and add manual trigger

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,9 +2,10 @@ name: .NET
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main, 'release/*' ]
   pull_request:
-    branches: [ main, develop ]
+    branches: [ main, 'release/*' ]
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- Configure CI workflow to run on `release/*` branches
- Remove `develop` branch from CI triggers
- Add `workflow_dispatch` to enable manual workflow runs on any branch

## Test plan
- Verify workflow triggers on pushes to release/* branches
- Verify workflow triggers on PRs to release/* branches
- Verify workflow can be manually triggered from Actions tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)